### PR TITLE
Use consistent "aws:cloudtrail" source type

### DIFF
--- a/rules/additional_aws_regions_enabled.yml
+++ b/rules/additional_aws_regions_enabled.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:EnableRegion
   eventSource:account.amazonaws.com
   | groupbycount(userIdentity.arn)

--- a/rules/amazon_bedrock_activity_invokemodel_multiple_regions_using_a_long_term_access_key.yml
+++ b/rules/amazon_bedrock_activity_invokemodel_multiple_regions_using_a_long_term_access_key.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:InvokeModel
   eventSource:bedrock.amazonaws.com
   userIdentity.accessKeyId:*AKIA*

--- a/rules/amazon_bedrock_console_activity_using_a_long_term_access_key.yml
+++ b/rules/amazon_bedrock_console_activity_using_a_long_term_access_key.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(GetFoundationModelAvailability PutUseCaseForModelAccess GetUseCaseForModelAccess CreateFoundationModelAgreement PutFoundationModelEntitlement)
   userIdentity.accessKeyId:AKIA*
   | groupbycount(userIdentity.arn)

--- a/rules/amazon_s3_bucket_policy_modified.yml
+++ b/rules/amazon_s3_bucket_policy_modified.yml
@@ -24,7 +24,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:(cloudtrail amazon-security-lake)
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(PutBucketAcl PutBucketPolicy PutBucketCors PutBucketLifecycle PutBucketReplication DeleteBucketPolicy DeleteBucketCors DeleteBucketReplication)
   | groupbycount(userIdentity.arn)
   | where @q.count > 0

--- a/rules/an_aws_account_attempted_to_leave_the_aws_organization.yml
+++ b/rules/an_aws_account_attempted_to_leave_the_aws_organization.yml
@@ -23,7 +23,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:LeaveOrganization
   eventSource:organizations.amazonaws.com
   | groupbycount(userIdentity.arn)

--- a/rules/attempt_to_create_xlarge_ec2_instances_in_multiple_aws_regions.yml
+++ b/rules/attempt_to_create_xlarge_ec2_instances_in_multiple_aws_regions.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(CreateInstance RunInstances)
   requestParameters.instanceType:*xlarge*
   | stats countdistinct(awsRegion) as num_distinct_values by userIdentity.arn

--- a/rules/aws_ami_made_public.yml
+++ b/rules/aws_ami_made_public.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:ModifyImageAttribute
   requestParameters.launchPermission.add.items.group:"all"
   | groupbycount(userIdentity.arn)

--- a/rules/aws_cloudwatch_log_group_deleted.yml
+++ b/rules/aws_cloudwatch_log_group_deleted.yml
@@ -16,7 +16,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:DeleteLogGroup
   (not errorCode:*)
   (not userAgent:(cloudformation.amazonaws.com *www.terraform.io*))

--- a/rules/aws_cloudwatch_rule_disabled_or_deleted.yml
+++ b/rules/aws_cloudwatch_rule_disabled_or_deleted.yml
@@ -20,7 +20,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:events.amazonaws.com
   eventName:(DisableRule DeleteRule)
   (not userIdentity.invokedBy:(backup.amazonaws.com schemas.amazonaws.com cloudformation.amazonaws.com))

--- a/rules/aws_detective_graph_deleted.yml
+++ b/rules/aws_detective_graph_deleted.yml
@@ -16,7 +16,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:detective.amazonaws.com
   eventName:DeleteGraph
   | groupbycount(userIdentity.arn)

--- a/rules/aws_ebs_default_encryption_disabled.yml
+++ b/rules/aws_ebs_default_encryption_disabled.yml
@@ -16,7 +16,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:(cloudtrail amazon-security-lake)
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:ec2.amazonaws.com
   eventName:DisableEbsEncryptionByDefault
   | groupbycount(userIdentity.arn)

--- a/rules/aws_ebs_snapshot_made_public.yml
+++ b/rules/aws_ebs_snapshot_made_public.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:ModifySnapshotAttribute
   requestParameters.createVolumePermission.add.items.group:"all"
   | groupbycount(userIdentity.arn)

--- a/rules/aws_ec2_subnet_deleted.yml
+++ b/rules/aws_ec2_subnet_deleted.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:ec2.amazonaws.com
   eventName:DeleteSubnet
   (not errorCode:*)

--- a/rules/aws_ecs_cluster_deleted.yml
+++ b/rules/aws_ecs_cluster_deleted.yml
@@ -16,7 +16,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:ecs.amazonaws.com
   eventName:DeleteCluster
   | groupbycount(userIdentity.arn)

--- a/rules/aws_ecs_createcluster_api_calls_in_multiple_regions.yml
+++ b/rules/aws_ecs_createcluster_api_calls_in_multiple_regions.yml
@@ -17,7 +17,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:CreateCluster
   eventSource:ecs.amazonaws.com
   | stats countdistinct(awsRegion) as num_distinct_values by userIdentity.arn

--- a/rules/aws_eventbridge_rule_disabled_or_deleted.yml
+++ b/rules/aws_eventbridge_rule_disabled_or_deleted.yml
@@ -21,7 +21,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:events.amazonaws.com
   eventName:(DeleteRule DisableRule)
   | groupbycount(userIdentity.arn, requestParameters.name)

--- a/rules/aws_guardduty_detector_deleted.yml
+++ b/rules/aws_guardduty_detector_deleted.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:DeleteDetector
   | groupbycount(userIdentity.arn)
   | where @q.count > 0

--- a/rules/aws_guardduty_publishing_destination_deleted.yml
+++ b/rules/aws_guardduty_publishing_destination_deleted.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:DeletePublishingDestination
   | groupbycount(userIdentity.arn)
   | where @q.count > 0

--- a/rules/aws_guardduty_threat_intel_set_deleted.yml
+++ b/rules/aws_guardduty_threat_intel_set_deleted.yml
@@ -21,7 +21,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:DeleteThreatIntelSet
   | groupbycount(userIdentity.arn)
   | where @q.count > 0

--- a/rules/aws_iam_administratoraccess_policy_was_applied_to_a_group.yml
+++ b/rules/aws_iam_administratoraccess_policy_was_applied_to_a_group.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:iam.amazonaws.com
   eventName:AttachGroupPolicy
   requestParameters.policyArn:"arn:aws:iam::aws:policy/AdministratorAccess"

--- a/rules/aws_iam_administratoraccess_policy_was_applied_to_a_role.yml
+++ b/rules/aws_iam_administratoraccess_policy_was_applied_to_a_role.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:iam.amazonaws.com
   eventName:AttachRolePolicy
   requestParameters.policyArn:"arn:aws:iam::aws:policy/AdministratorAccess"

--- a/rules/aws_iam_administratoraccess_policy_was_applied_to_a_user.yml
+++ b/rules/aws_iam_administratoraccess_policy_was_applied_to_a_user.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:iam.amazonaws.com
   eventName:AttachUserPolicy
   requestParameters.policyArn:"arn:aws:iam::aws:policy/AdministratorAccess"

--- a/rules/aws_iam_roles_anywhere_trust_anchor_created.yml
+++ b/rules/aws_iam_roles_anywhere_trust_anchor_created.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:CreateTrustAnchor
   eventSource:rolesanywhere.amazonaws.com
   | groupbycount(userIdentity.arn)

--- a/rules/aws_java_ghost_security_group_creation_attempt.yml
+++ b/rules/aws_java_ghost_security_group_creation_attempt.yml
@@ -13,7 +13,7 @@ description: |-
 enabled: true
 severity: Critical
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:CreateSecurityGroup
   requestParameters.groupName:"Java_Ghost"
   | groupbycount(userIdentity.arn)

--- a/rules/aws_kinesis_firehose_stream_destination_modified.yml
+++ b/rules/aws_kinesis_firehose_stream_destination_modified.yml
@@ -15,7 +15,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:firehose.amazonaws.com
   eventName:UpdateDestination
   (not userAgent:(cloudformation.amazonaws.com APN\\/*))

--- a/rules/aws_kms_key_deleted_or_scheduled_for_deletion.yml
+++ b/rules/aws_kms_key_deleted_or_scheduled_for_deletion.yml
@@ -17,7 +17,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:(cloudtrail amazon-security-lake)
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(DisableKey ScheduleKeyDeletion)
   | groupbycount(userIdentity.arn)
   | where @q.count > 0

--- a/rules/aws_lambda_function_modified_by_iam_user.yml
+++ b/rules/aws_lambda_function_modified_by_iam_user.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:lambda.amazonaws.com
   eventName:UpdateFunctionCode*
   userIdentity.type:IAMUser

--- a/rules/aws_lambda_function_resource_based_policy_modified_by_iam_user.yml
+++ b/rules/aws_lambda_function_resource_based_policy_modified_by_iam_user.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:lambda.amazonaws.com
   eventName:AddPermission*
   userIdentity.type:IAMUser

--- a/rules/aws_principal_added_to_multiple_eks_clusters.yml
+++ b/rules/aws_principal_added_to_multiple_eks_clusters.yml
@@ -20,7 +20,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(CreateAccessEntry AssociateAccessPolicy)
   | stats countdistinct(requestParameters.name) as num_distinct_values by requestParameters.principalArn, recipientAccountId
   | where num_distinct_values > 5

--- a/rules/aws_rds_cluster_deleted.yml
+++ b/rules/aws_rds_cluster_deleted.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   (not errorCode:*)
   eventName:DeleteDBCluster
   | groupbycount(userIdentity.arn)

--- a/rules/aws_route_53_dns_query_logging_disabled.yml
+++ b/rules/aws_route_53_dns_query_logging_disabled.yml
@@ -14,7 +14,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   (not errorCode:*)
   eventName:DeleteResolverQueryLogConfig
   | groupbycount(userIdentity.arn)

--- a/rules/aws_s3_bucket_acl_made_public.yml
+++ b/rules/aws_s3_bucket_acl_made_public.yml
@@ -24,7 +24,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:PutBucketAcl
   (not errorCode:*)
   requestParameters.AccessControlPolicy.AccessControlList.Grant.Grantee.URI:("http://acs.amazonaws.com/groups/global/AuthenticatedUsers" "http://acs.amazonaws.com/groups/global/AllUsers")

--- a/rules/aws_s3_public_access_block_removed.yml
+++ b/rules/aws_s3_public_access_block_removed.yml
@@ -16,7 +16,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   (not errorCode:*)
   eventName:DeleteAccountPublicAccessBlock
   | groupbycount(userIdentity.arn)

--- a/rules/aws_ses_discovery_attempt_by_long_term_access_key.yml
+++ b/rules/aws_ses_discovery_attempt_by_long_term_access_key.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(GetAccount ListServiceQuotas)
   eventSource:ses.amazonaws.com
   userIdentity.accessKeyId:AKIA*

--- a/rules/aws_ses_email_sending_enabled_in_current_aws_region.yml
+++ b/rules/aws_ses_email_sending_enabled_in_current_aws_region.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:(UpdateAccountSendingEnabled PutAccountSendingAttributes)
   (@requestParameters.enabled : true or requestParameters.sendingEnabled:true)
   userIdentity.accessKeyId:AKIA*

--- a/rules/aws_vpc_flow_log_deleted.yml
+++ b/rules/aws_vpc_flow_log_deleted.yml
@@ -18,7 +18,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:DeleteFlowLogs
   eventSource:ec2.amazonaws.com
   | groupbycount(userIdentity.arn)

--- a/rules/aws_waf_web_access_control_list_deleted.yml
+++ b/rules/aws_waf_web_access_control_list_deleted.yml
@@ -13,7 +13,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:waf*.amazonaws.com
   eventName:DeleteWebACL
   (not userAgent:\\APN\\/*)

--- a/rules/aws_waf_web_access_control_list_modified.yml
+++ b/rules/aws_waf_web_access_control_list_modified.yml
@@ -13,7 +13,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:waf*.amazonaws.com
   eventName:UpdateWebACL
   (not userAgent:(\\APN\\/* cloudformation.amazonaws.com))

--- a/rules/cloudtrail_secretsmanager_secret_retrieved_from_aws_cloudshell_environment.yml
+++ b/rules/cloudtrail_secretsmanager_secret_retrieved_from_aws_cloudshell_environment.yml
@@ -17,7 +17,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   userAgent:*exec-env/CloudShell*
   eventName:GetSecretValue
   | groupbycount(userIdentity.arn)

--- a/rules/encrypted_administrator_password_retrieved_for_windows_ec2_instance.yml
+++ b/rules/encrypted_administrator_password_retrieved_for_windows_ec2_instance.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:GetPasswordData
   eventSource:ec2.amazonaws.com
   errorCode:*

--- a/rules/new_public_repository_container_image_detected_in_aws_ecr.yml
+++ b/rules/new_public_repository_container_image_detected_in_aws_ecr.yml
@@ -13,7 +13,7 @@ description: |-
 enabled: true
 severity: Informational
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventSource:ecr-public.amazonaws.com
   eventName:PutImage
   (not errorCode:ImageAlreadyExistsException)

--- a/rules/possible_privilege_escalation_via_aws_login_profile_manipulation.yml
+++ b/rules/possible_privilege_escalation_via_aws_login_profile_manipulation.yml
@@ -19,7 +19,7 @@ description: |-
 enabled: true
 severity: Low
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   (not errorCode:*)
   eventName:(CreateLoginProfile UpdateLoginProfile)
   | groupbycount(userIdentity.arn)

--- a/rules/security_group_open_to_the_world.yml
+++ b/rules/security_group_open_to_the_world.yml
@@ -21,7 +21,7 @@ description: |-
 enabled: true
 severity: Medium
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   eventName:AuthorizeSecurityGroupIngress
   requestParameters.ipPermissions.items.ipRanges.items.cidrIp:("0.0.0.0/0" "::/0")
   | groupbycount(recipientAccountId)

--- a/rules/trufflehog_user_agent_observed_in_aws.yml
+++ b/rules/trufflehog_user_agent_observed_in_aws.yml
@@ -17,7 +17,7 @@ description: |-
 enabled: true
 severity: High
 query_text: |-
-  %ingest.source_type:cloudtrail
+  %ingest.source_type:"aws:cloudtrail"
   userAgent:TruffleHog
   eventName:GetCallerIdentity
   | groupbycount(userIdentity.arn)


### PR DESCRIPTION
From user feedback. Make source type consistent - use `"aws:cloudtrail"` everywhere.

Also, remove `amazon-security-lake` source type. Not often ingested by users. Can re-evaluate later.