### PR TITLE
Quote unsupported barewords

### DIFF
--- a/rules/aws_waf_web_access_control_list_deleted.yml
+++ b/rules/aws_waf_web_access_control_list_deleted.yml
@@ -16,7 +16,7 @@ query_text: |-
   %ingest.source_type:"aws:cloudtrail"
   eventSource:waf*.amazonaws.com
   eventName:DeleteWebACL
-  (not userAgent:\\APN\\/*)
+  (not userAgent:"\\APN\\/*")
   | groupbycount(userIdentity.arn)
   | where @q.count > 0
 time_range_s: 300

--- a/rules/aws_waf_web_access_control_list_modified.yml
+++ b/rules/aws_waf_web_access_control_list_modified.yml
@@ -16,7 +16,7 @@ query_text: |-
   %ingest.source_type:"aws:cloudtrail"
   eventSource:waf*.amazonaws.com
   eventName:UpdateWebACL
-  (not userAgent:(\\APN\\/* cloudformation.amazonaws.com))
+  (not userAgent:("\\APN\\/*" cloudformation.amazonaws.com))
   | groupbycount(userIdentity.arn)
   | where @q.count > 0
 time_range_s: 300


### PR DESCRIPTION
Barewords can no longer start with `\`.