### PR TITLE
Remove `enabled` field from rules

### DIFF
--- a/rules/additional_aws_regions_enabled.yml
+++ b/rules/additional_aws_regions_enabled.yml
@@ -15,7 +15,6 @@ description: |-
      - Check the user investigation dashboard for other actions taken by the user.
      - Investigate the IP for any unusual traffic patterns.
   4. If evidence suggests an attack, initiate the incident response process and conduct a thorough investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/amazon_bedrock_activity_invokemodel_multiple_regions_using_a_long_term_access_key.yml
+++ b/rules/amazon_bedrock_activity_invokemodel_multiple_regions_using_a_long_term_access_key.yml
@@ -16,7 +16,6 @@ description: |-
      * Check the User Investigation dashboard for other actions taken by the user (the user's ARN).
      * Check the IP Investigation dashboard for additional traffic from the IP (the client IP).
   4. If the triage results suggest an attacker is involved, initiate the incident response process and investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/amazon_bedrock_console_activity_using_a_long_term_access_key.yml
+++ b/rules/amazon_bedrock_console_activity_using_a_long_term_access_key.yml
@@ -15,7 +15,6 @@ description: |-
      * Investigate the user's other actions.
      * Check for additional traffic from the specified IP address.
   4. If evidence suggests an attack, initiate the incident response process and conduct further investigation.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/amazon_s3_bucket_policy_modified.yml
+++ b/rules/amazon_s3_bucket_policy_modified.yml
@@ -21,7 +21,6 @@ description: |-
   3. If the call was unauthorized:
      * Rotate the user's credentials and investigate other API calls they made.
      * Identify additional API calls made by the user that were not authorized.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/an_aws_account_attempted_to_leave_the_aws_organization.yml
+++ b/rules/an_aws_account_attempted_to_leave_the_aws_organization.yml
@@ -20,7 +20,6 @@ description: |-
      * Communicate with the user to confirm if this was a planned action.
      * If not planned, review other API calls by the user for further investigation.
      * Initiate your company's incident response process.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/an_aws_s3_bucket_lifecycle_expiration_policy_was_set_to_disabled.yml
+++ b/rules/an_aws_s3_bucket_lifecycle_expiration_policy_was_set_to_disabled.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage & Response
   1. Determine if the event should have occurred on the specified bucket by the identified user and account.
   2. If the bucket should not be disabled, escalate to engineering for re-enablement.
-enabled: true
 severity: Informational
 query_text: |-
   (not errorCode:*)

--- a/rules/an_aws_s3_bucket_lifecycle_policy_expiration_is_set_to_90_days.yml
+++ b/rules/an_aws_s3_bucket_lifecycle_policy_expiration_is_set_to_90_days.yml
@@ -12,7 +12,6 @@ description: |-
   ## Triage & Response
   1. Determine if the event should have occurred on the specified bucket by the username, account ID, and type, and verify that the bucket has a file expiration of less than 90 days.
   2. If the bucket is the CloudTrail bucket, consider escalating to higher severity and investigating further.
-enabled: true
 severity: Low
 query_text: |-
   eventName:PutBucketLifecycle

--- a/rules/attempt_to_create_xlarge_ec2_instances_in_multiple_aws_regions.yml
+++ b/rules/attempt_to_create_xlarge_ec2_instances_in_multiple_aws_regions.yml
@@ -15,7 +15,6 @@ description: |-
     * Delete any associated EC2 security groups or key pairs.
     * Review other API calls made by the user.
     * Initiate the organization's incident response process and conduct an investigation.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ami_made_public.yml
+++ b/rules/aws_ami_made_public.yml
@@ -16,7 +16,6 @@ description: |-
       * Investigate if the same credentials were used for other unauthorized API calls.
       * Revert AMI permissions to their original state.
       * Begin your company's incident response process and investigate.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_attached_malicious_lambda_layer.yml
+++ b/rules/aws_attached_malicious_lambda_layer.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Attached Malicious Lambda Layer
-enabled: true
 description: |-
   Detects when an user attached a Lambda layer to an existing function to override a library that is in use by the function, where their malicious code could utilize the function's IAM role for AWS API calls.
   This would give an adversary access to the privileges associated with the Lambda service role that is attached to that function.

--- a/rules/aws_cloudtrail_disable_logging.yml
+++ b/rules/aws_cloudtrail_disable_logging.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS CloudTrail Important Change
-enabled: true
 description: |-
   Detects disabling, deleting and updating of a Trail
 

--- a/rules/aws_cloudwatch_log_group_deleted.yml
+++ b/rules/aws_cloudwatch_log_group_deleted.yml
@@ -13,7 +13,6 @@ description: |-
       * Verify that the user making this API call is authorized in your environment.
       * Consider adding the log group name to a suppression list.
   3. If it is not for auditing or security, initiate your company's incident response process and investigate.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_cloudwatch_rule_disabled_or_deleted.yml
+++ b/rules/aws_cloudwatch_rule_disabled_or_deleted.yml
@@ -17,7 +17,6 @@ description: |-
      * Check if the user was authorized for this change.
      * If authorized, consider adding the event bus name to a suppression list.
      * If not authorized, re-enable or create a rule as previously mentioned and initiate your incident response process to investigate.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_config_disable_recording.yml
+++ b/rules/aws_config_disable_recording.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Config Disabling Channel/Recorder
-enabled: true
 description: |-
   Detects AWS Config Service disabling
 

--- a/rules/aws_console_getsignintoken.yml
+++ b/rules/aws_console_getsignintoken.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Console GetSigninToken Potential Abuse
-enabled: true
 description: |-
   Detects potentially suspicious events involving "GetSigninToken".
   An adversary using the "aws_consoler" tool can leverage this console API to create temporary federated credential that help obfuscate which AWS credential is compromised (the original access key) and enables the adversary to pivot from the AWS CLI to console sessions without the need for MFA using the new access key issued in this request.

--- a/rules/aws_delete_identity.yml
+++ b/rules/aws_delete_identity.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: SES Identity Has Been Deleted
-enabled: true
 description: |-
   Detects an instance of an SES identity being deleted via the "DeleteIdentity" event. This may be an indicator of an adversary removing the account that carried out suspicious or malicious activities
 

--- a/rules/aws_detective_graph_deleted.yml
+++ b/rules/aws_detective_graph_deleted.yml
@@ -13,7 +13,6 @@ description: |-
   3. If the deletion was unauthorized:
      * Rotate the credentials.
      * Investigate for any other unauthorized API calls made with the same credentials.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_disable_bucket_versioning.yml
+++ b/rules/aws_disable_bucket_versioning.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS S3 Bucket Versioning Disable
-enabled: true
 description: |-
   Detects when S3 bucket versioning is disabled. Threat actors use this technique during AWS ransomware incidents prior to deleting S3 objects.
 

--- a/rules/aws_ebs_default_encryption_disabled.yml
+++ b/rules/aws_ebs_default_encryption_disabled.yml
@@ -13,7 +13,6 @@ description: |-
   3. Re-enable EBS encryption by default.
 
   For more information about Amazon EBS Encryption, refer to the Amazon EBS Encryption documentation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ebs_snapshot_made_public.yml
+++ b/rules/aws_ebs_snapshot_made_public.yml
@@ -16,7 +16,6 @@ description: |-
       * Investigate other potential unauthorized API calls.
       * Revert AMI permissions to the original state.
       * Initiate the incident response process.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ec2_disable_encryption.yml
+++ b/rules/aws_ec2_disable_encryption.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS EC2 Disable EBS Encryption
-enabled: true
 description: |-
   Identifies disabling of default Amazon Elastic Block Store (EBS) encryption in the current region.
   Disabling default encryption does not change the encryption status of your existing volumes.

--- a/rules/aws_ec2_startup_script_change.yml
+++ b/rules/aws_ec2_startup_script_change.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS EC2 Startup Shell Script Change
-enabled: true
 description: |-
   Detects changes to the EC2 instance startup script. The shell script will be executed as root/SYSTEM every time the specific instances are booted up.
 

--- a/rules/aws_ec2_subnet_deleted.yml
+++ b/rules/aws_ec2_subnet_deleted.yml
@@ -15,7 +15,6 @@ description: |-
   3. If the user did not make the API call:
      * Rotate the credentials.
      * Investigate if the same credentials made other unauthorized API calls.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ec2_vm_export_failure.yml
+++ b/rules/aws_ec2_vm_export_failure.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS EC2 VM Export Failure
-enabled: true
 description: |-
   An attempt to export an AWS EC2 instance has been detected. A VM Export might indicate an attempt to extract information from an instance.
 

--- a/rules/aws_ecs_cluster_deleted.yml
+++ b/rules/aws_ecs_cluster_deleted.yml
@@ -13,7 +13,6 @@ description: |-
   3. If the user did not make the API call:
       * Rotate the credentials.
       * Investigate if the same credentials made other unauthorized API calls.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ecs_createcluster_api_calls_in_multiple_regions.yml
+++ b/rules/aws_ecs_createcluster_api_calls_in_multiple_regions.yml
@@ -14,7 +14,6 @@ description: |-
     * Remove the newly created cluster and any associated tasks or services.
     * Investigate what other API calls were made by the user.
     * Initiate your organization's incident response process.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ecs_task_definition_cred_endpoint_query.yml
+++ b/rules/aws_ecs_task_definition_cred_endpoint_query.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS ECS Task Definition That Queries The Credential Endpoint
-enabled: true
 description: |-
   Detects when an Elastic Container Service (ECS) Task Definition includes a command to query the credential endpoint.
   This can indicate a potential adversary adding a backdoor to establish persistence or escalate privileges.

--- a/rules/aws_efs_fileshare_modified_or_deleted.yml
+++ b/rules/aws_efs_fileshare_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS EFS Fileshare Modified or Deleted
-enabled: true
 description: |-
   Detects when a EFS Fileshare is modified or deleted.
   You can't delete a file system that is in use.

--- a/rules/aws_efs_fileshare_mount_modified_or_deleted.yml
+++ b/rules/aws_efs_fileshare_mount_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS EFS Fileshare Mount Modified or Deleted
-enabled: true
 description: |-
   Detects when a EFS Fileshare Mount is modified or deleted. An adversary breaking any file system using the mount target that is being deleted, which might disrupt instances or applications using those mounts.
 

--- a/rules/aws_eks_cluster_created_or_deleted.yml
+++ b/rules/aws_eks_cluster_created_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS EKS Cluster Created or Deleted
-enabled: true
 description: |-
   Identifies when an EKS cluster is created or deleted.
 

--- a/rules/aws_elasticache_security_group_created.yml
+++ b/rules/aws_elasticache_security_group_created.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS ElastiCache Security Group Created
-enabled: true
 description: |-
   Detects when an ElastiCache security group has been created.
 

--- a/rules/aws_elasticache_security_group_modified_or_deleted.yml
+++ b/rules/aws_elasticache_security_group_modified_or_deleted.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS ElastiCache Security Group Modified or Deleted
-enabled: true
 description: |-
   Identifies when an ElastiCache security group has been modified or deleted.
 

--- a/rules/aws_enum_buckets.yml
+++ b/rules/aws_enum_buckets.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Potential Bucket Enumeration on AWS
-enabled: true
 description: |-
   Looks for potential enumeration of AWS buckets via ListBuckets.
 

--- a/rules/aws_eventbridge_rule_disabled_or_deleted.yml
+++ b/rules/aws_eventbridge_rule_disabled_or_deleted.yml
@@ -18,7 +18,6 @@ description: |-
       * Investigate any other unauthorized API calls made with the same credentials.
 
   **NOTE:** Tune out valid user agents that trigger this alert. For guidance, refer to relevant tuning resources.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_guardduty_detector_deleted.yml
+++ b/rules/aws_guardduty_detector_deleted.yml
@@ -15,7 +15,6 @@ description: |-
   3. If the user did not make the call:
       * Rotate the credentials.
       * Investigate any other unauthorized API calls made with the same credentials.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_guardduty_disruption.yml
+++ b/rules/aws_guardduty_disruption.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS GuardDuty Important Change
-enabled: true
 description: |-
   Detects updates of the GuardDuty list of trusted IPs, perhaps to disable security alerts against malicious IPs.
 

--- a/rules/aws_guardduty_publishing_destination_deleted.yml
+++ b/rules/aws_guardduty_publishing_destination_deleted.yml
@@ -15,7 +15,6 @@ description: |-
   3. If the user did not make the API call:
       * Rotate the credentials.
       * Investigate if the same credentials made other unauthorized API calls.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_guardduty_threat_intel_set_deleted.yml
+++ b/rules/aws_guardduty_threat_intel_set_deleted.yml
@@ -18,7 +18,6 @@ description: |-
   3. If the API call was made by the user:
     * Verify if the user was authorized to perform this API call.
     * If not authorized, check for additional API calls by the user and assess for further investigation.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_iam_administratoraccess_policy_was_applied_to_a_group.yml
+++ b/rules/aws_iam_administratoraccess_policy_was_applied_to_a_group.yml
@@ -16,7 +16,6 @@ description: |-
   3. If the API call was made legitimately by the user:
     * Assess if the group requires the AdministratorAccess policy for its intended function.
     * Advise the user to find the least privileged policy that allows the group to operate as intended.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_iam_administratoraccess_policy_was_applied_to_a_role.yml
+++ b/rules/aws_iam_administratoraccess_policy_was_applied_to_a_role.yml
@@ -16,7 +16,6 @@ description: |-
   3. If the API call was legitimate:
     * Assess whether the role needs the AdministratorAccess policy for its functions.
     * Recommend the user find a least privileged policy that meets the role's operational requirements.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_iam_administratoraccess_policy_was_applied_to_a_user.yml
+++ b/rules/aws_iam_administratoraccess_policy_was_applied_to_a_user.yml
@@ -16,7 +16,6 @@ description: |-
   3. If the API call was made legitimately:
      * Assess if the user requires the AdministratorAccess policy for their tasks.
      * Advise the user to seek the least privileged policy that meets their operational needs.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_iam_roles_anywhere_trust_anchor_created.yml
+++ b/rules/aws_iam_roles_anywhere_trust_anchor_created.yml
@@ -16,7 +16,6 @@ description: |-
      * Initiate your organization's incident response process.
   3. If the API call was legitimate:
      * Ensure that using an IAM Roles Anywhere trust anchor is appropriate for the resource.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_iam_s3browser_loginprofile_creation.yml
+++ b/rules/aws_iam_s3browser_loginprofile_creation.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS IAM S3Browser LoginProfile Creation
-enabled: true
 description: |-
   Detects S3 Browser utility performing reconnaissance looking for existing IAM Users without a LoginProfile defined then (when found) creating a LoginProfile.
 

--- a/rules/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
+++ b/rules/aws_iam_s3browser_templated_s3_bucket_policy_creation.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS IAM S3Browser Templated S3 Bucket Policy Creation
-enabled: true
 description: |-
   Detects S3 browser utility creating Inline IAM policy containing default S3 bucket name placeholder value of "<YOUR-BUCKET-NAME>".
 

--- a/rules/aws_iam_s3browser_user_or_accesskey_creation.yml
+++ b/rules/aws_iam_s3browser_user_or_accesskey_creation.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS IAM S3Browser User or AccessKey Creation
-enabled: true
 description: |-
   Detects S3 Browser utility creating IAM User or AccessKey.
 

--- a/rules/aws_java_ghost_security_group_creation_attempt.yml
+++ b/rules/aws_java_ghost_security_group_creation_attempt.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and Response
   1. Review past activity and API calls made by the compromised identity.
   2. Initiate your company's incident response process and conduct an investigation.
-enabled: true
 severity: Critical
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_kinesis_firehose_stream_destination_modified.yml
+++ b/rules/aws_kinesis_firehose_stream_destination_modified.yml
@@ -12,7 +12,6 @@ description: |-
   2. If the API call was not made by the user, rotate the user credentials and investigate other successfully accessed APIs.
      * Rotate the credentials.
      * Investigate if the same credentials made other unauthorized API calls.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_kms_key_deleted_or_scheduled_for_deletion.yml
+++ b/rules/aws_kms_key_deleted_or_scheduled_for_deletion.yml
@@ -14,7 +14,6 @@ description: |-
   2. If the user did not make the API call:
       * Rotate the credentials.
       * Investigate other potential unauthorized API calls from this user.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_lambda_function_modified_by_iam_user.yml
+++ b/rules/aws_lambda_function_modified_by_iam_user.yml
@@ -15,7 +15,6 @@ description: |-
      * Check the User Investigation dashboard for other actions taken by the user.
      * Review the IP Investigation dashboard for additional traffic from the client's IP.
   4. If an attack is suspected, initiate your organization's incident response process and investigation.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_lambda_function_resource_based_policy_modified_by_iam_user.yml
+++ b/rules/aws_lambda_function_resource_based_policy_modified_by_iam_user.yml
@@ -16,7 +16,6 @@ description: |-
      * Check the User Investigation dashboard for other actions taken by the user.
      * Check the IP Investigation dashboard for additional traffic from the client's IP.
   5. If an attack is suspected, initiate the company's incident response process and conduct further investigation.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_passed_role_to_glue_development_endpoint.yml
+++ b/rules/aws_passed_role_to_glue_development_endpoint.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Glue Development Endpoint Activity
-enabled: true
 description: |-
   Detects possible suspicious glue development endpoint activity.
 

--- a/rules/aws_principal_added_to_multiple_eks_clusters.yml
+++ b/rules/aws_principal_added_to_multiple_eks_clusters.yml
@@ -17,7 +17,6 @@ description: |-
   4. If the API calls were made by the user:
      * Evaluate if the user should be granting access to the cluster.
      * If not, investigate other API calls made by the user for further implications.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_rds_change_master_password.yml
+++ b/rules/aws_rds_change_master_password.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS RDS Master Password Change
-enabled: true
 description: |-
   Detects the change of database master password. It may be a part of data exfiltration.
 

--- a/rules/aws_rds_cluster_deleted.yml
+++ b/rules/aws_rds_cluster_deleted.yml
@@ -16,7 +16,6 @@ description: |-
   3. If the API call was not made by the user:
      * Rotate the user credentials.
      * Investigate other API calls made with the old credentials that were not authorized by the user.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_rds_public_db_restore.yml
+++ b/rules/aws_rds_public_db_restore.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: Restore Public AWS RDS Instance
-enabled: true
 description: |-
   Detects the recovery of a new public database instance from a snapshot. It may be a part of data exfiltration.
 

--- a/rules/aws_root_account_usage.yml
+++ b/rules/aws_root_account_usage.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Root Credentials
-enabled: true
 description: |-
   Detects AWS root account usage
 

--- a/rules/aws_route_53_dns_query_logging_disabled.yml
+++ b/rules/aws_route_53_dns_query_logging_disabled.yml
@@ -11,7 +11,6 @@ description: |-
   1. Determine if the user identity is expected to perform the "DeleteResolverQueryLogConfig" API call.
   2. Contact the principal owner to verify if the API call was initiated by the user.
   3. If the API call was not user-initiated, rotate user credentials and investigate other successfully accessed APIs.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_route_53_domain_transferred_lock_disabled.yml
+++ b/rules/aws_route_53_domain_transferred_lock_disabled.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Route 53 Domain Transfer Lock Disabled
-enabled: true
 description: |-
   Detects when a transfer lock was removed from a Route 53 domain. It is recommended to refrain from performing this action unless intending to transfer the domain to a different registrar.
 

--- a/rules/aws_route_53_domain_transferred_to_another_account.yml
+++ b/rules/aws_route_53_domain_transferred_to_another_account.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Route 53 Domain Transferred to Another Account
-enabled: true
 description: |-
   Detects when a request has been made to transfer a Route 53 domain to another AWS account.
 

--- a/rules/aws_s3_bucket_acl_made_public.yml
+++ b/rules/aws_s3_bucket_acl_made_public.yml
@@ -23,7 +23,6 @@ description: |-
   3. If the API call was unauthorized, rotate the user credentials and investigate other successful API accesses:
      * Rotate the credentials.
      * Check for other unauthorized API calls with the same credentials.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_s3_data_management_tampering.yml
+++ b/rules/aws_s3_data_management_tampering.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS S3 Data Management Tampering
-enabled: true
 description: |-
   Detects when a user tampers with S3 data management in Amazon Web Services.
 

--- a/rules/aws_s3_public_access_block_removed.yml
+++ b/rules/aws_s3_public_access_block_removed.yml
@@ -17,7 +17,6 @@ description: |-
   3. Re-enable Public Access Block on the S3 bucket.
 
   More details on S3 Public Block Public Access can be found [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html).
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_securityhub_finding_evasion.yml
+++ b/rules/aws_securityhub_finding_evasion.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS SecurityHub Findings Evasion
-enabled: true
 description: |-
   Detects the modification of the findings on SecurityHub.
 

--- a/rules/aws_ses_discovery_attempt_by_long_term_access_key.yml
+++ b/rules/aws_ses_discovery_attempt_by_long_term_access_key.yml
@@ -15,7 +15,6 @@ description: |-
      * Check the user investigation dashboard for other actions taken by the user.
      * Check the IP investigation dashboard for additional traffic from the IP.
   4. If the triage results suggest an attack, initiate your company's incident response process and investigation.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_ses_email_sending_enabled_in_current_aws_region.yml
+++ b/rules/aws_ses_email_sending_enabled_in_current_aws_region.yml
@@ -15,7 +15,6 @@ description: |-
      * Check the User Investigation dashboard for other actions taken by the user.
      * Review the IP Investigation dashboard for additional traffic from the IP.
   4. If findings suggest an attack, initiate your company's incident response process and investigation.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_snapshot_backup_exfiltration.yml
+++ b/rules/aws_snapshot_backup_exfiltration.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Snapshot Backup Exfiltration
-enabled: true
 description: |-
   Detects the modification of an EC2 snapshot's permissions to enable access from another account
 

--- a/rules/aws_sso_idp_change.yml
+++ b/rules/aws_sso_idp_change.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Identity Center Identity Provider Change
-enabled: true
 description: |-
   Detects a change in the AWS Identity Center (FKA AWS SSO) identity provider.
   A change in identity provider allows an attacker to establish persistent access or escalate privileges via user impersonation.

--- a/rules/aws_sts_getsessiontoken_misuse.yml
+++ b/rules/aws_sts_getsessiontoken_misuse.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS STS GetSessionToken Misuse
-enabled: true
 description: |-
   Identifies the suspicious use of GetSessionToken. Tokens could be created and used by attackers to move laterally and escalate privileges.
 

--- a/rules/aws_susp_saml_activity.yml
+++ b/rules/aws_susp_saml_activity.yml
@@ -1,6 +1,5 @@
 # schema: https://scanner.dev/schema/scanner-detection-rule.v1.json
 name: AWS Suspicious SAML Activity
-enabled: true
 description: |-
   Identifies when suspicious SAML activity has occurred in AWS. An adversary could gain backdoor access via SAML.
 

--- a/rules/aws_vpc_flow_log_deleted.yml
+++ b/rules/aws_vpc_flow_log_deleted.yml
@@ -15,7 +15,6 @@ description: |-
   4. If the API call was unauthorized:
      - Rotate the user credentials.
      - Investigate other API calls made with the old credentials that were not authorized by the user.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_waf_web_access_control_list_deleted.yml
+++ b/rules/aws_waf_web_access_control_list_deleted.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Determine if the user's identity is expected to perform the "DeleteWebACL" API call on the account.
   2. If the API call was not made by the user, rotate the user credentials and investigate what other APIs were successfully accessed.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/aws_waf_web_access_control_list_modified.yml
+++ b/rules/aws_waf_web_access_control_list_modified.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage and response
   1. Verify if the user identity is authorized to perform the "UpdateWebACL" API call on the account.
   2. If the API call was unauthorized, rotate the user's credentials and investigate other successfully accessed APIs.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/cloudtrail_secretsmanager_secret_retrieved_from_aws_cloudshell_environment.yml
+++ b/rules/cloudtrail_secretsmanager_secret_retrieved_from_aws_cloudshell_environment.yml
@@ -14,7 +14,6 @@ description: |-
      * Rotate the retrieved secrets, if feasible.
      * Investigate other API calls made by the user.
      * Initiate your organization's incident response process.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/encrypted_administrator_password_retrieved_for_windows_ec2_instance.yml
+++ b/rules/encrypted_administrator_password_retrieved_for_windows_ec2_instance.yml
@@ -16,7 +16,6 @@ description: |-
      * Determine if the user should access the EC2 instance.
      * If yes, advise them to speak with the instance owner to resolve the issue.
      * If no, review other API calls made by the user for further investigation.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/new_public_repository_container_image_detected_in_aws_ecr.yml
+++ b/rules/new_public_repository_container_image_detected_in_aws_ecr.yml
@@ -10,7 +10,6 @@ description: |-
   ## Triage & Response
   1. Verify that the image ID is a valid SHA256 hash for the container image with the specified tag in the designated repository on the AWS account.
   2. If the hash is invalid, investigate whether the container image was uploaded for malicious reasons.
-enabled: true
 severity: Informational
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/possible_privilege_escalation_via_aws_login_profile_manipulation.yml
+++ b/rules/possible_privilege_escalation_via_aws_login_profile_manipulation.yml
@@ -16,7 +16,6 @@ description: |-
   3. If the API call was made by the user:
     - Verify if the user should be making this API call.
     - If not, check for other API calls made by the user to assess if further investigation is necessary.
-enabled: true
 severity: Low
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/security_group_open_to_the_world.yml
+++ b/rules/security_group_open_to_the_world.yml
@@ -18,7 +18,6 @@ description: |-
   3. If the API call was unauthorized:
     * Rotate the user's credentials and investigate any other unauthorized API calls.
     * Review other API calls made by the user.
-enabled: true
 severity: Medium
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"

--- a/rules/trufflehog_user_agent_observed_in_aws.yml
+++ b/rules/trufflehog_user_agent_observed_in_aws.yml
@@ -14,7 +14,6 @@ description: |-
       * If necessary, disable or rotate the affected credential.
       * Investigate any actions taken by the identity.
       * Collaborate with relevant teams to remove the key from source code repositories.
-enabled: true
 severity: High
 query_text: |-
   @scnr.source_type:"aws:cloudtrail"


### PR DESCRIPTION
Support staging state for out-of-the-box rules. The enabled flag should not take precedence when users add rules with staging state.